### PR TITLE
Improve description of branch targeting for action release management

### DIFF
--- a/content/actions/learn-github-actions/finding-and-customizing-actions.md
+++ b/content/actions/learn-github-actions/finding-and-customizing-actions.md
@@ -79,7 +79,7 @@ steps:
 
 #### Using branches
 
-Referring to a specific branch means that the action will always use the latest updates on the target branch, but can create problems if those updates include breaking changes. This example targets a branch named `@main`:
+Specifying a target branch for the action means it will always run the version currently on that branch. This approach can create problems if an update to the branch includes breaking changes. This example targets a branch named `@main`:
 
 ```yaml
 steps:


### PR DESCRIPTION
### Why:

- Fix #2290
- Sentence needs rephrasing/simplification

### What's being changed:

- Clarify use of target branch
- Separate clauses for ease of reading
- Remove unnecessary conjunction
- Replace pronoun to eliminate ambiguity

### Check off the following:

- [ ] I have reviewed my changes in staging (look for the **deploy-to-heroku** link in your pull request, then click **View deployment**)
- [x] For content changes, I have reviewed the [localization checklist](https://github.com/github/docs/blob/main/contributing/localization-checklist.md)
- [x] For content changes, I have reviewed the [content style guide for GitHub Docs](https://github.com/github/docs/blob/main/contributing/content-style-guide.md)
